### PR TITLE
Add `monthsFixedGrid` to render months like a paper calendar

### DIFF
--- a/.changeset/dirty-frogs-train.md
+++ b/.changeset/dirty-frogs-train.md
@@ -1,0 +1,6 @@
+---
+"@tempocal/react": minor
+"@tempocal/www": minor
+---
+
+Add monthsFixedGrid to render months like a paper calendar

--- a/packages/react/src/Calendar.tsx
+++ b/packages/react/src/Calendar.tsx
@@ -5,6 +5,7 @@ import {
   getWeekdays,
 } from "@tempocal/core";
 import * as React from "react";
+import { CSSProperties } from "react";
 import { Locale } from "./useTempocal";
 
 type Value = Temporal.PlainDate | Temporal.PlainDateTime;
@@ -13,6 +14,7 @@ type MonthProps = {
   locale: Locale;
   maxValue?: Temporal.PlainDate | undefined;
   minValue?: Temporal.PlainDate | undefined;
+  normalizeRenderedWeeks?: boolean;
   rollover?: boolean;
   startOfWeek?: number;
   value: Value;
@@ -76,6 +78,7 @@ export function Calendar({
   minValue,
   monthsAfter = 0,
   monthsBefore = 0,
+  normalizeRenderedWeeks,
   rollover,
   startOfWeek,
   value,
@@ -105,6 +108,7 @@ export function Calendar({
           locale={locale}
           maxValue={maxValue}
           minValue={minValue}
+          normalizeRenderedWeeks={normalizeRenderedWeeks}
           rollover={rollover}
           startOfWeek={startOfWeek}
           value={value.add({ months: month - monthsBefore })}
@@ -127,6 +131,7 @@ function Month({
   locale,
   maxValue,
   minValue,
+  normalizeRenderedWeeks = false,
   rollover = false,
   startOfWeek = 7,
   value,
@@ -160,6 +165,19 @@ function Month({
     [end, start]
   );
 
+  const firstDay = days.at(0);
+
+  const gridColumnStart =
+    !rollover && firstDay
+      ? startOfWeek > firstDay.dayOfWeek
+        ? firstDay.daysInWeek - (startOfWeek - firstDay.dayOfWeek) + 1
+        : Math.abs(startOfWeek - firstDay.dayOfWeek) + 1
+      : undefined;
+
+  const daysToPadAfter = normalizeRenderedWeeks
+    ? start.daysInWeek * 6 - start.daysInMonth - (gridColumnStart || 0) + 1
+    : 0;
+
   return (
     <ul
       {...calendarProps?.()}
@@ -187,17 +205,38 @@ function Month({
         <Day
           key={date.dayOfYear}
           date={date}
-          day={day}
           disabled={
             (!!minValue && Temporal.PlainDate.compare(date, minValue) < 0) ||
             (!!maxValue && Temporal.PlainDate.compare(date, maxValue) > 0)
           }
           dayProps={dayProps}
+          style={day === 0 ? { gridColumnStart } : undefined}
           renderDay={renderDay}
-          rollover={rollover}
-          startOfWeek={startOfWeek}
         />
       ))}
+      {daysToPadAfter > 0 && firstDay && (
+        <>
+          {[...Array(Math.floor(daysToPadAfter / firstDay.daysInWeek))].map(
+            (_, index) => (
+              <Day
+                key={index}
+                date={firstDay}
+                disabled
+                dayProps={dayProps}
+                style={{
+                  gridColumn: `span ${Math.min(
+                    daysToPadAfter,
+                    firstDay.daysInWeek
+                  )}`,
+                  opacity: daysToPadAfter,
+                  visibility: "hidden",
+                }}
+                renderDay={renderDay}
+              />
+            )
+          )}
+        </>
+      )}
       {renderFooter && (
         <li
           {...footerProps?.({ date: monthStartDate })}
@@ -214,18 +253,14 @@ function Month({
 
 function Day({
   date,
-  day,
   disabled,
   dayProps,
   renderDay,
-  rollover,
-  startOfWeek,
+  style,
 }: Pick<MonthProps, "dayProps" | "renderDay"> & {
   date: Temporal.PlainDate;
-  day: number;
   disabled: boolean;
-  rollover: boolean;
-  startOfWeek: number;
+  style: CSSProperties | undefined;
 }) {
   const props = React.useMemo(() => {
     const plainDateLike: Temporal.PlainDateLike = {
@@ -243,19 +278,7 @@ function Day({
   }, [date, disabled]);
 
   return (
-    <li
-      {...dayProps?.(props)}
-      style={
-        !rollover && day === 0
-          ? {
-              gridColumnStart:
-                startOfWeek > date.dayOfWeek
-                  ? date.daysInWeek - (startOfWeek - date.dayOfWeek) + 1
-                  : Math.abs(startOfWeek - date.dayOfWeek) + 1,
-            }
-          : undefined
-      }
-    >
+    <li {...dayProps?.(props)} style={style}>
       {renderDay ? renderDay(props) : date.day}
     </li>
   );

--- a/packages/react/src/Calendar.tsx
+++ b/packages/react/src/Calendar.tsx
@@ -14,7 +14,7 @@ type MonthProps = {
   locale: Locale;
   maxValue?: Temporal.PlainDate | undefined;
   minValue?: Temporal.PlainDate | undefined;
-  normalizeRenderedWeeks?: boolean;
+  monthsFixedGrid?: boolean;
   rollover?: boolean;
   startOfWeek?: number;
   value: Value;
@@ -78,7 +78,7 @@ export function Calendar({
   minValue,
   monthsAfter = 0,
   monthsBefore = 0,
-  normalizeRenderedWeeks,
+  monthsFixedGrid,
   rollover,
   startOfWeek,
   value,
@@ -108,7 +108,7 @@ export function Calendar({
           locale={locale}
           maxValue={maxValue}
           minValue={minValue}
-          normalizeRenderedWeeks={normalizeRenderedWeeks}
+          monthsFixedGrid={monthsFixedGrid}
           rollover={rollover}
           startOfWeek={startOfWeek}
           value={value.add({ months: month - monthsBefore })}
@@ -131,7 +131,7 @@ function Month({
   locale,
   maxValue,
   minValue,
-  normalizeRenderedWeeks = false,
+  monthsFixedGrid = false,
   rollover = false,
   startOfWeek = 7,
   value,
@@ -174,7 +174,7 @@ function Month({
         : Math.abs(startOfWeek - firstDay.dayOfWeek) + 1
       : undefined;
 
-  const daysToPadAfter = normalizeRenderedWeeks
+  const daysToPadAfter = monthsFixedGrid
     ? start.daysInWeek * 6 - start.daysInMonth - (gridColumnStart || 0) + 1
     : 0;
 

--- a/packages/www/examples/DateRangePicker.tsx
+++ b/packages/www/examples/DateRangePicker.tsx
@@ -18,11 +18,11 @@ const dateFormatter = new Intl.DateTimeFormat(locale, {
 export function DateRangePicker({
   monthsAfter,
   monthsBefore,
-  normalizeRenderedWeeks,
+  monthsFixedGrid,
 }: {
   monthsAfter: number;
   monthsBefore: number;
-  normalizeRenderedWeeks: boolean;
+  monthsFixedGrid: boolean;
 }) {
   const [values, setValues] = React.useState<DateRange>([
     Temporal.Now.plainDate("iso8601").subtract({ days: 3 }),
@@ -61,7 +61,7 @@ export function DateRangePicker({
         {...calendarProps}
         monthsBefore={monthsBefore}
         monthsAfter={monthsAfter}
-        normalizeRenderedWeeks={normalizeRenderedWeeks}
+        monthsFixedGrid={monthsFixedGrid}
         calendarProps={() => ({
           className: "gap-1 text-center w-72",
         })}

--- a/packages/www/examples/DateRangePicker.tsx
+++ b/packages/www/examples/DateRangePicker.tsx
@@ -18,9 +18,11 @@ const dateFormatter = new Intl.DateTimeFormat(locale, {
 export function DateRangePicker({
   monthsAfter,
   monthsBefore,
+  normalizeRenderedWeeks,
 }: {
   monthsAfter: number;
   monthsBefore: number;
+  normalizeRenderedWeeks: boolean;
 }) {
   const [values, setValues] = React.useState<DateRange>([
     Temporal.Now.plainDate("iso8601").subtract({ days: 3 }),
@@ -59,6 +61,7 @@ export function DateRangePicker({
         {...calendarProps}
         monthsBefore={monthsBefore}
         monthsAfter={monthsAfter}
+        normalizeRenderedWeeks={normalizeRenderedWeeks}
         calendarProps={() => ({
           className: "gap-1 text-center w-72",
         })}

--- a/packages/www/pages/examples/DateRangePicker.tsx
+++ b/packages/www/pages/examples/DateRangePicker.tsx
@@ -12,8 +12,7 @@ export default function DateRangePickerPage(
   const [monthsBefore, setMonthsBefore] = React.useState(0);
   const [monthsAfter, setMonthsAfter] = React.useState(0);
 
-  const [normalizeRenderedWeeks, setNormalizeRenderedWeeks] =
-    React.useState(true);
+  const [monthsFixedGrid, setMonthsFixedGrid] = React.useState(true);
 
   return (
     <Example
@@ -21,7 +20,7 @@ export default function DateRangePickerPage(
         <DateRangePicker
           monthsAfter={monthsAfter}
           monthsBefore={monthsBefore}
-          normalizeRenderedWeeks={normalizeRenderedWeeks}
+          monthsFixedGrid={monthsFixedGrid}
         />
       }
       title="DateRangePicker"
@@ -50,15 +49,13 @@ export default function DateRangePickerPage(
           value={monthsAfter}
         />
         <Checkbox
-          checked={normalizeRenderedWeeks}
-          hint="Always render the calendar with the same number of weeks, as if it were a paper calendar."
-          id="normalizeRenderedWeeks"
-          label="normalizeRenderedWeeks"
-          name="normalizeRenderedWeeks"
+          checked={monthsFixedGrid}
+          hint="Always render months on the same grid, as if it were a paper calendar"
+          id="monthsFixedGrid"
+          label="monthsFixedGrid"
+          name="monthsFixedGrid"
           onChange={() => {
-            setNormalizeRenderedWeeks(
-              (normalizeRenderedWeeks) => !normalizeRenderedWeeks
-            );
+            setMonthsFixedGrid((monthsFixedGrid) => !monthsFixedGrid);
           }}
         />
       </fieldset>

--- a/packages/www/pages/examples/DateRangePicker.tsx
+++ b/packages/www/pages/examples/DateRangePicker.tsx
@@ -1,5 +1,6 @@
 import { InferGetStaticPropsType } from "next";
 import * as React from "react";
+import { Checkbox } from "../../components/Checkbox";
 import { Example } from "../../components/Example";
 import { Input } from "../../components/Input";
 import { DateRangePicker } from "../../examples/DateRangePicker";
@@ -11,12 +12,16 @@ export default function DateRangePickerPage(
   const [monthsBefore, setMonthsBefore] = React.useState(0);
   const [monthsAfter, setMonthsAfter] = React.useState(0);
 
+  const [normalizeRenderedWeeks, setNormalizeRenderedWeeks] =
+    React.useState(true);
+
   return (
     <Example
       demo={
         <DateRangePicker
           monthsAfter={monthsAfter}
           monthsBefore={monthsBefore}
+          normalizeRenderedWeeks={normalizeRenderedWeeks}
         />
       }
       title="DateRangePicker"
@@ -43,6 +48,18 @@ export default function DateRangePickerPage(
           onChange={({ target: { value } }) => setMonthsAfter(Number(value))}
           type="number"
           value={monthsAfter}
+        />
+        <Checkbox
+          checked={normalizeRenderedWeeks}
+          hint="Always render the calendar with the same number of weeks, as if it were a paper calendar."
+          id="normalizeRenderedWeeks"
+          label="normalizeRenderedWeeks"
+          name="normalizeRenderedWeeks"
+          onChange={() => {
+            setNormalizeRenderedWeeks(
+              (normalizeRenderedWeeks) => !normalizeRenderedWeeks
+            );
+          }}
         />
       </fieldset>
     </Example>

--- a/packages/www/pages/react/Calendar.tsx
+++ b/packages/www/pages/react/Calendar.tsx
@@ -24,6 +24,7 @@ return (
     {...calendarProps}
     monthsAfter={number}
     monthsBefore={number}
+    monthsFixedGrid={boolean}
     rollover={boolean}
     startOfWeek={number}
     calendarProps={() => React.DetailedHTMLProps<React.HTMLAttributes<HTMLUListElement>, HTMLUListElement>}
@@ -52,6 +53,19 @@ return (
             <p>Number of months to display before the primary calendar.</p>
             <CodeBlock>{`monthsBefore?: number`}</CodeBlock>
             <em className="block">Defaults to 0</em>
+          </div>
+          <div className="space-y-2">
+            <AnchorHeader id="props-monthsFixedGrid">
+              monthsFixedGrid
+            </AnchorHeader>
+            <p>
+              Always render months on the same grid, as if it were a paper
+              calendar. Useful to avoid content shifting and to align multiple
+              months with <Code>monthsAfter</Code> and <Code>monthsBefore</Code>
+              .
+            </p>
+            <CodeBlock>{`monthsFixedGrid?: boolean`}</CodeBlock>
+            <em className="block">Defaults to false</em>
           </div>
           <div className="space-y-2">
             <AnchorHeader id="props-rollover">rollover</AnchorHeader>


### PR DESCRIPTION
- [x] Docs
- [x] Changeset

Without `monthsFixedGrid`:
![image](https://github.com/Zertz/tempocal/assets/2636763/ccd9da20-65e2-4b99-ab09-6fd9b6bdbbe0)

With `monthsFixedGrid`:
![image](https://github.com/Zertz/tempocal/assets/2636763/3dea7345-f048-458a-8c95-d4d8781d94d2)
